### PR TITLE
Fix missing libfty-scripts-rest1.postinst

### DIFF
--- a/packaging/debian/libfty-scripts-rest1.postinst
+++ b/packaging/debian/libfty-scripts-rest1.postinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Create scripts directory
+mkdir -p /var/lib/fty/fty-scripts-rest
+chgrp www-data -R /var/lib/fty/fty-scripts-rest
+chmod g+rwxs /var/lib/fty/fty-scripts-rest


### PR DESCRIPTION
File got misplaced with packaging reworking.